### PR TITLE
use env variable to determine GitHub API URL

### DIFF
--- a/logic.js
+++ b/logic.js
@@ -1,6 +1,8 @@
 const childProcess = require("child_process");
 const fs = require('fs');
-const octokit = require('@octokit/rest')();
+const octokit = require('@octokit/rest')({
+    baseUrl: process.env.GITHUB_API_URL,
+});
 
 function buildAnnotations() {
   const val = fs.readFileSync("/result.json", "utf-8");


### PR DESCRIPTION
This PR leverages the always present environment variable [`GITHUB_API_URL`](https://docs.github.com/en/actions/learn-github-actions/environment-variables) to determine the API URL to be used for creating checks. 
This allows the action to run as well against self-hosted GitHub Enterprise Servers. On github.com the `GITHUB_API_URL` is the standard `https://api.github.com`. 